### PR TITLE
Add words from Joseph Kimble's list

### DIFF
--- a/index.json
+++ b/index.json
@@ -1,6 +1,7 @@
 [
   "ab initio",
   "above mentioned",
+  "above named",
   "above-mentioned",
   "abutting",
   "aforegoing",

--- a/index.json
+++ b/index.json
@@ -12,6 +12,7 @@
   "aforethought",
   "allocatur",
   "anent",
+  "arguendo",
   "aver",
   "bona fide",
   "by and through",

--- a/index.json
+++ b/index.json
@@ -131,6 +131,7 @@
   "ultra vires",
   "unless and until",
   "unto",
+  "vel non",
   "whereas",
   "whereat",
   "whereby",

--- a/index.json
+++ b/index.json
@@ -148,5 +148,6 @@
   "wheresoever",
   "whereunder",
   "whereupon",
+  "whosoever",
   "witnesseth"
 ]

--- a/index.json
+++ b/index.json
@@ -122,6 +122,7 @@
   "thereto",
   "theretofore",
   "thereunder",
+  "thereunto",
   "thereupon",
   "therewith",
   "thine",

--- a/index.json
+++ b/index.json
@@ -85,6 +85,7 @@
   "pari passu",
   "per annum",
   "per diem",
+  "premises",
   "prima facie",
   "pro tanto",
   "qui tam",

--- a/index.json
+++ b/index.json
@@ -17,6 +17,7 @@
   "before mentioned",
   "before-mentioned",
   "below mentioned",
+  "below named",
   "below-mentioned",
   "bona fide",
   "by and through",

--- a/index.json
+++ b/index.json
@@ -1,5 +1,6 @@
 [
   "ab initio",
+  "above mentioned",
   "abutting",
   "aforegoing",
   "aforementioned",

--- a/index.json
+++ b/index.json
@@ -96,6 +96,7 @@
   "sets forth",
   "setting forth",
   "ss.",
+  "sub judice",
   "sui generis",
   "telegram",
   "telegraph",

--- a/index.json
+++ b/index.json
@@ -67,6 +67,7 @@
   "in rem",
   "indebtedness",
   "instant case",
+  "instanter",
   "ipso facto",
   "know all men by these presents",
   "mala fides",

--- a/index.json
+++ b/index.json
@@ -69,6 +69,7 @@
   "instant case",
   "instant matter",
   "instanter",
+  "inter alia",
   "ipso facto",
   "know all men by these presents",
   "mala fides",

--- a/index.json
+++ b/index.json
@@ -66,6 +66,7 @@
   "in personam",
   "in rem",
   "indebtedness",
+  "instant case",
   "ipso facto",
   "know all men by these presents",
   "mala fides",

--- a/index.json
+++ b/index.json
@@ -95,6 +95,7 @@
   "set forth",
   "sets forth",
   "setting forth",
+  "ss.",
   "sui generis",
   "telegram",
   "telegraph",

--- a/index.json
+++ b/index.json
@@ -16,6 +16,7 @@
   "aver",
   "before mentioned",
   "before-mentioned",
+  "below mentioned",
   "bona fide",
   "by and through",
   "cablegram",

--- a/index.json
+++ b/index.json
@@ -132,6 +132,7 @@
   "unless and until",
   "unto",
   "vel non",
+  "viz.",
   "whereas",
   "whereat",
   "whereby",

--- a/index.json
+++ b/index.json
@@ -14,6 +14,7 @@
   "anent",
   "arguendo",
   "aver",
+  "before mentioned",
   "bona fide",
   "by and through",
   "cablegram",

--- a/index.json
+++ b/index.json
@@ -39,6 +39,7 @@
   "foregoing",
   "hast",
   "hath",
+  "henceforth",
   "hereabout",
   "hereabouts",
   "hereafter",

--- a/index.json
+++ b/index.json
@@ -70,6 +70,7 @@
   "instant matter",
   "instanter",
   "inter alia",
+  "inter se",
   "ipso facto",
   "know all men by these presents",
   "mala fides",

--- a/index.json
+++ b/index.json
@@ -3,6 +3,7 @@
   "above mentioned",
   "above named",
   "above-mentioned",
+  "above-named",
   "abutting",
   "aforegoing",
   "aforementioned",

--- a/index.json
+++ b/index.json
@@ -130,6 +130,7 @@
   "to wit",
   "ultra vires",
   "unless and until",
+  "unto",
   "whereas",
   "whereat",
   "whereby",

--- a/index.json
+++ b/index.json
@@ -133,6 +133,7 @@
   "unto",
   "vel non",
   "viz.",
+  "whatsoever",
   "whereas",
   "whereat",
   "whereby",

--- a/index.json
+++ b/index.json
@@ -47,6 +47,7 @@
   "hereby",
   "herein",
   "hereinabove",
+  "hereinafter",
   "hereinbelow",
   "hereof",
   "hereon",

--- a/index.json
+++ b/index.json
@@ -17,6 +17,7 @@
   "before mentioned",
   "before-mentioned",
   "below mentioned",
+  "below-mentioned",
   "bona fide",
   "by and through",
   "cablegram",

--- a/index.json
+++ b/index.json
@@ -134,6 +134,7 @@
   "vel non",
   "viz.",
   "whatsoever",
+  "whensoever",
   "whereas",
   "whereat",
   "whereby",

--- a/index.json
+++ b/index.json
@@ -15,6 +15,7 @@
   "arguendo",
   "aver",
   "before mentioned",
+  "before-mentioned",
   "bona fide",
   "by and through",
   "cablegram",

--- a/index.json
+++ b/index.json
@@ -1,6 +1,7 @@
 [
   "ab initio",
   "above mentioned",
+  "above-mentioned",
   "abutting",
   "aforegoing",
   "aforementioned",

--- a/index.json
+++ b/index.json
@@ -48,6 +48,7 @@
   "herein",
   "hereinabove",
   "hereinafter",
+  "hereinbefore",
   "hereinbelow",
   "hereof",
   "hereon",

--- a/index.json
+++ b/index.json
@@ -150,5 +150,6 @@
   "whereupon",
   "whosoever",
   "within named",
+  "within-named",
   "witnesseth"
 ]

--- a/index.json
+++ b/index.json
@@ -67,6 +67,7 @@
   "in rem",
   "indebtedness",
   "instant case",
+  "instant matter",
   "instanter",
   "ipso facto",
   "know all men by these presents",

--- a/index.json
+++ b/index.json
@@ -5,6 +5,7 @@
   "above-mentioned",
   "above-named",
   "abutting",
+  "ad idem",
   "aforegoing",
   "aforementioned",
   "aforesaid",

--- a/index.json
+++ b/index.json
@@ -97,6 +97,7 @@
   "setting forth",
   "ss.",
   "sub judice",
+  "such",
   "sui generis",
   "telegram",
   "telegraph",

--- a/index.json
+++ b/index.json
@@ -91,6 +91,7 @@
   "qui tam",
   "res judicata",
   "said",
+  "same",
   "set forth",
   "sets forth",
   "setting forth",

--- a/index.json
+++ b/index.json
@@ -19,6 +19,7 @@
   "below mentioned",
   "below named",
   "below-mentioned",
+  "below-named",
   "bona fide",
   "by and through",
   "cablegram",

--- a/index.json
+++ b/index.json
@@ -23,6 +23,7 @@
   "bona fide",
   "by and through",
   "cablegram",
+  "case at bar",
   "comes now",
   "contra proferentem",
   "datagram",

--- a/index.json
+++ b/index.json
@@ -32,6 +32,7 @@
   "de minimis",
   "de novo",
   "ejusdem generis",
+  "ex contractu",
   "ex gratia",
   "ex parte",
   "foregoing",

--- a/index.json
+++ b/index.json
@@ -149,5 +149,6 @@
   "whereunder",
   "whereupon",
   "whosoever",
+  "within named",
   "witnesseth"
 ]

--- a/index.json
+++ b/index.json
@@ -90,6 +90,7 @@
   "pro tanto",
   "qui tam",
   "res judicata",
+  "said",
   "set forth",
   "sets forth",
   "setting forth",

--- a/index.json
+++ b/index.json
@@ -11,6 +11,7 @@
   "aforesaid",
   "aforethought",
   "allocatur",
+  "anent",
   "aver",
   "bona fide",
   "by and through",

--- a/index.json
+++ b/index.json
@@ -33,6 +33,7 @@
   "de novo",
   "ejusdem generis",
   "ex contractu",
+  "ex delicto",
   "ex gratia",
   "ex parte",
   "foregoing",


### PR DESCRIPTION
@anseljh: These words are from the last page of Joseph Kimble's _Plain Words (Part 2)_, 80 Mich. B.J. 72 (Aug. 2001), which I found via Wayne Schiess' _Preparing Plain Legal Documents for Nonlawyers_.

There is a script to add them automatically on the `kimble` branch, but I thought I'd go ahead and run these by you as concrete patches.

In particular, I'd be curious to know if you consider any of these additions overly aggressive. I think I'd agree that they all tend to give writing a legal smell, but I'm not sure that's because they're all archaic, at least across usage.

In case you're wondering: yes, there is more stuff in Kimble's articles for word-words. The data file for all of Kimble's lists is:

https://github.com/commonform/kimble-plain-words.json
